### PR TITLE
updated docker build to run with m1 chip

### DIFF
--- a/dhcp/run_test
+++ b/dhcp/run_test
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-docker build --network host -t test .
+docker build --platform=linux/amd64 --network host -t test .
 docker run --network host -t test
-

--- a/security_logging/run_test
+++ b/security_logging/run_test
@@ -1,2 +1,2 @@
-docker build --network host -t syslog_test --build-arg syslog_endpoint_ip=${SYSLOG_ENDPOINT_IP} .
+docker build --platform=linux/amd64 --network host -t syslog_test --build-arg syslog_endpoint_ip=${SYSLOG_ENDPOINT_IP} .
 docker run --network host -t syslog_test


### PR DESCRIPTION
The DHCP & security logging docker containers do not work! I don't think they have ever worked looking though the commit messages! It is accepted by the team that adding the flag '--platform=linux/amd64' is a good positive change with no negative impact, thus I am adding the change in here. Under a seperate ticket we should review this repo and try to identify if its still needed & if it is fix it.